### PR TITLE
Bug fix. Large file will be truncated during export due to passing 'message' (last piece) instead of 'self.__buffer' (whole piece).

### DIFF
--- a/three/_scanner.py
+++ b/three/_scanner.py
@@ -202,7 +202,7 @@ class Scanner:
                 else:
                     self.__buffer = message
                 if self.__bufferDescriptor.Size == len(self.__buffer):
-                    self.OnBuffer(self.__bufferDescriptor, message)
+                    self.OnBuffer(self.__bufferDescriptor, self.__buffer)
                     self.__bufferDescriptor = None 
                     self.__buffer = None
         else:


### PR DESCRIPTION
Solve large file transfer truncation issue.

## Description

When exporting a large file, such as a high quality scan (larger than 64MB), the received 'bytes' data in the callback function ```OnBuffer``` is truncated.

Fixes # (issue)

Replace line 205
```                    self.OnBuffer(self.__bufferDescriptor, message)```
in ```_scanner.py``` with
```                    self.OnBuffer(self.__bufferDescriptor, self.__buffer)```
(Although in fact I directly modified the ```scanner.py``` in my case)


## Type of change

- [* ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A. But here is a short description:
Take a high quality scan (which will generate a zip file larger than 64MB) and perform export operation. The received file is intact after applying the change. Otherwise the following error message will be displayed when unzipping:
```error [scan.zip]: missing 64000000 bytes in zipfile (attempting to process anyway)```

**Test Configuration**:
* Platform you tested on (Ubuntu 22.04, Pi Bullseye etc)
* Ubuntu 22.04
* Python 3.10.12
* mfthree 11.7.1 (with this bug fix modificaiton)

# Checklist:

- [ ] (Not sure) My code follows the style guidelines of this project
- [ ] (N/A) I have filled out Doxygen style comments in all headers.
- [ ] (N/A) I have added new and simple unit tests to check my work
- [ ] (N/A) All Unit tests pass locally with my changes
- [ ] (N/A) I have assigned someone for review and notified them directly
